### PR TITLE
Add possibility to login  with any collection of type auth

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,6 +58,12 @@ func WithUserEmailPassword(email, password string) ClientOption {
 	}
 }
 
+func WithEmailPassword(collection, email, password string) ClientOption {
+	return func(c *Client) {
+		c.authorizer = newAuthorizeEmailPassword(c.client, c.url+"/api/collections/"+collection+"/auth-with-password", email, password)
+	}
+}
+
 func WithAdminToken(token string) ClientOption {
 	return func(c *Client) {
 		c.authorizer = newAuthorizeToken(c.client, c.url+"/api/admins/auth-refresh", token)


### PR DESCRIPTION
Pocketbase allow us to define any collection as type auth collection. So it is necessary that we provide a way that any collection can be used to login.
I added a method that allow to select the collection.